### PR TITLE
support `PRIVATE` and `BITSET` futex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ axerrno = { git = "https://github.com/Starry-OS/axerrno.git" }
 axconfig = { git = "https://github.com/Starry-OS/axconfig.git" }
 axfs = { git = "https://github.com/Starry-OS/axfs.git", optional = true }
 axsignal = { git = "https://github.com/Starry-OS/axsignal.git" }
+axfutex = { git = "https://github.com/Starry-OS/axfutex.git" }
 riscv = "0.10"
 bitflags = "2.0"
 lazy_static = { version = "1.4", features = ["spin_no_std"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -26,6 +26,7 @@ use elf_parser::{
 use xmas_elf::program::SegmentData;
 
 use crate::flags::WaitStatus;
+use crate::futex::futex_wake;
 use crate::link::real_path;
 use crate::process::{Process, PID2PC, TID2TASK};
 
@@ -96,6 +97,7 @@ pub fn exit_current_task(exit_code: i32) -> ! {
         {
             unsafe {
                 *(clear_child_tid as *mut i32) = 0;
+                let _ = futex_wake(clear_child_tid.into(), 0, 1);
             }
         }
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -26,7 +26,6 @@ use elf_parser::{
 use xmas_elf::program::SegmentData;
 
 use crate::flags::WaitStatus;
-use crate::futex::clear_wait;
 use crate::link::real_path;
 use crate::process::{Process, PID2PC, TID2TASK};
 
@@ -67,14 +66,6 @@ pub fn exit_current_task(exit_code: i32) -> ! {
     let curr_id = current_task.id().as_u64();
 
     info!("exit task id {} with code _{}_", curr_id, exit_code);
-    clear_wait(
-        if current_task.is_leader() {
-            process.pid()
-        } else {
-            curr_id
-        },
-        current_task.is_leader(),
-    );
     // 检查这个任务是否有sig_child信号
     let exit_signal = process
         .signal_modules

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -1,44 +1,10 @@
 //! 实现与futex相关的系统调用
-use alloc::collections::{BTreeMap, VecDeque};
-use axhal::mem::VirtAddr;
-use axsync::Mutex;
-use axtask::{AxTaskRef, WaitQueue};
-
-use crate::current_process;
+use axtask::WaitQueue;
 
 extern crate alloc;
 
-/// vec中的元素分别是任务指针,对应存储时的futex变量的值
-pub static FUTEX_WAIT_TASK: Mutex<BTreeMap<FutexKey, VecDeque<(AxTaskRef, u32)>>> =
-    Mutex::new(BTreeMap::new());
-
 /// waiting queue which stores tasks waiting for futex variable
 pub static WAIT_FOR_FUTEX: WaitQueue = WaitQueue::new();
-
-/// Futexes are matched on equal values of this key.
-///
-/// The key type depends on whether it's a shared or private mapping.
-/// use pid to replace the mm_struct pointer
-#[derive(Copy, Clone, Default, Ord, PartialOrd, Eq, PartialEq)]
-pub struct FutexKey {
-    ptr: u64,
-    word: usize,
-    offset: u32,
-}
-
-impl FutexKey {
-    fn new(ptr: u64, word: usize, offset: u32) -> Self {
-        Self { ptr, word, offset }
-    }
-}
-/// 获取futex变量的key
-/// TODO: shared futex and error handling
-pub fn get_futex_key(uaddr: VirtAddr, _flags: i32) -> FutexKey {
-    let ptr = current_process().pid();
-    let offset = uaddr.align_offset_4k() as u32;
-    let word = uaddr.align_down_4k().as_usize();
-    FutexKey::new(ptr, word, offset)
-}
 
 #[derive(Default)]
 /// 用于存储 robust list 的结构
@@ -54,30 +20,4 @@ impl FutexRobustList {
     pub fn new(head: usize, len: usize) -> Self {
         Self { head, len }
     }
-}
-
-/// 退出的时候清空指针
-///
-/// 若当前线程是主线程，代表进程退出，此时传入的id是进程id，要清除所有进程下的线程
-///
-/// 否则传入的id是线程id
-pub fn clear_wait(id: u64, leader: bool) {
-    let mut futex_wait_task = FUTEX_WAIT_TASK.lock();
-
-    if leader {
-        // 清空所有所属进程为指定进程的线程
-        futex_wait_task.iter_mut().for_each(|(_, tasks)| {
-            // tasks.drain_filter(|task| task.get_process_id() == id);
-            tasks.retain(|(task, _)| task.get_process_id() != id);
-        });
-    } else {
-        futex_wait_task.iter_mut().for_each(|(_, tasks)| {
-            // tasks.drain_filter(|task| task.id().as_u64() == id);
-            tasks.retain(|(task, _)| task.id().as_u64() != id)
-        });
-    }
-
-    // 如果一个共享变量不会被线程所使用了，那么直接把他移除
-    // info!("clean pre keys: {:?}", futex_wait_task.keys());
-    futex_wait_task.retain(|_, tasks| !tasks.is_empty());
 }

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -1,10 +1,20 @@
 //! 实现与futex相关的系统调用
-use axtask::WaitQueue;
+use axhal::mem::VirtAddr;
+use axlog::info;
+use core::time::Duration;
+use crate::{current_process, current_task, signal::current_have_signals, yield_now_task};
+use axerrno::LinuxError;
+use axfutex::{flags::FLAGS_SHARED, futex::{FutexKey, FutexQ}, queues::{futex_hash, FUTEXQUEUES}};
+//use axtask::WaitQueue;
+
 
 extern crate alloc;
 
+
+pub type AxSyscallResult = Result<isize, axerrno::LinuxError>;
+
 /// waiting queue which stores tasks waiting for futex variable
-pub static WAIT_FOR_FUTEX: WaitQueue = WaitQueue::new();
+//pub static WAIT_FOR_FUTEX: WaitQueue = WaitQueue::new();
 
 #[derive(Default)]
 /// 用于存储 robust list 的结构
@@ -20,4 +30,202 @@ impl FutexRobustList {
     pub fn new(head: usize, len: usize) -> Self {
         Self { head, len }
     }
+}
+
+pub fn futex_get_value_locked(vaddr: VirtAddr) -> AxSyscallResult {
+    let process = current_process();
+    if process.manual_alloc_for_lazy(vaddr).is_ok() {
+        let real_futex_val = unsafe { (vaddr.as_usize() as *const u32).read_volatile() };
+        Ok(real_futex_val as isize)
+    }
+    else {
+        Err(LinuxError::EFAULT)
+    }
+}
+
+pub fn get_futex_key(uaddr: VirtAddr, flags: i32) -> FutexKey {
+    if flags & FLAGS_SHARED != 0 {
+        /* Todo: after implement inode layer 
+        let inode = uaddr.get_inode();
+        let page_index = uaddr.get_page_index();
+        let offset = uaddr.get_offset();
+        FutexKey::new(inode, page_index, offset)
+        */
+        let pid = current_process().pid();
+        let aligned = uaddr.align_down_4k().as_usize();
+        let offset = uaddr.align_offset_4k() as u32;
+        return FutexKey::new(pid, aligned, offset);
+    }
+    else {
+        let pid = current_process().pid();
+        let aligned = uaddr.align_down_4k().as_usize();
+        let offset = uaddr.align_offset_4k() as u32;
+        return FutexKey::new(pid, aligned, offset);
+    } 
+}
+
+pub fn futex_wait(vaddr: VirtAddr, flags: i32, expected_val: u32, deadline: Option<Duration>, bitset: u32) -> AxSyscallResult {
+    info!("[futex_wait] current task: {:?}, vaddr: {:?}, flags: {:?}, val: {:?}, deadline: {:?}", current_task().id(), vaddr, flags, expected_val, deadline);
+    let mut is_timeout = false;
+
+    // we may be victim of spurious wakeups, so we need to loop
+    loop {
+        let key = get_futex_key(vaddr, flags);
+        let real_futex_val = futex_get_value_locked(vaddr)?;
+        if expected_val != real_futex_val as u32 {
+            return Err(LinuxError::EAGAIN);
+        }
+        // 比较后相等，放入等待队列
+        let mut hash_bucket= FUTEXQUEUES.buckets[futex_hash(&key)].lock();
+        let cur_futexq = FutexQ::new(key, current_task().as_task_ref().clone(), bitset);
+        hash_bucket.push_back(cur_futexq);
+
+        // drop lock to avoid deadlock
+        drop(hash_bucket);
+
+        /* There is something wrong with WaitQueues, tasks are woken up unexpectedly
+        if let Some(deadline) = deadline {
+            // There is something wrong with WaitQueues
+            is_tiemout = WAIT_FOR_FUTEX.wait_timeout(deadline);
+        }
+        else {
+            // If timeout is NULL, the operation can block indefinitely.
+            yield_now_task();
+        }
+        */
+
+        if let Some(deadline) = deadline {
+            let now = axhal::time::current_time();
+            is_timeout = deadline < now;
+        }
+        if deadline.is_none() || !is_timeout {
+            yield_now_task();
+        }
+
+        // If we were woken (and unqueued), we succeeded, whatever. 
+        // We doesn't care about the reason of wakeup if we were unqueued.
+        let mut hash_bucket= FUTEXQUEUES.buckets[futex_hash(&key)].lock();
+        let cur_id = current_task().id().as_u64();
+        //if let Some(idx) = hash_bucket.iter().position(|futex_q| futex_q.task.id().as_u64() == cur_id) {
+        if let Some(idx) = hash_bucket.iter().position(|futex_q| futex_q.task.id().as_u64() == cur_id) {
+            hash_bucket.remove(idx);
+            if is_timeout {
+                return Err(LinuxError::ETIMEDOUT);
+            }
+            if current_have_signals() {
+                return Err(LinuxError::EINTR);
+            }
+        }
+        else {
+            // the task is woken up anyway
+            return Ok(0);
+        }
+    }
+}
+
+
+
+// no need to check the bitset, faster than futex_wake_bitset
+pub fn futex_wake(vaddr: VirtAddr, flags: i32, nr_waken: u32) -> AxSyscallResult {
+    info!("[futex_wake] vaddr: {:?}, flags: {:?}, nr_waken: {:?}", vaddr, flags, nr_waken);
+    let mut ret = 0;
+    let key = get_futex_key(vaddr, flags);
+    let mut hash_bucket= FUTEXQUEUES.buckets[futex_hash(&key)].lock();
+
+
+    if hash_bucket.is_empty() {
+        info!("hash_bucket is empty");
+        return Ok(0);
+    } 
+    else {
+        hash_bucket.retain(|futex_q| {
+            if ret < nr_waken && futex_q.key == key {
+                //let wake_up = WAIT_FOR_FUTEX.notify_task(&futex_q.task);
+                info!("wake up task {:?}", futex_q.task.id());
+                ret += 1;
+                return false;
+            }
+            true
+        })
+    }
+    // drop hash_bucket to avoid deadlock 
+    drop(hash_bucket);
+    yield_now_task();
+    info!("[futex_wake] wake up {:?} tasks", ret);
+    Ok(ret as isize)
+}
+
+pub fn futex_wake_bitset(vaddr: VirtAddr, flags: i32, nr_waken: u32, bitset: u32) -> AxSyscallResult {
+    info!("[futex_wake_bitset] vaddr: {:?}, flags: {:?}, nr_waken: {:?}, bitset: {:x}", vaddr, flags, nr_waken, bitset);
+    if bitset == 0 {
+        return Err(LinuxError::EINVAL);
+    }
+    let mut ret = 0;
+    let key = get_futex_key(vaddr, flags);
+    let mut hash_bucket= FUTEXQUEUES.buckets[futex_hash(&key)].lock();
+    if hash_bucket.is_empty() {
+        return Ok(0);
+    } 
+    else {
+        hash_bucket.retain(|futex_q| {
+            if ret == nr_waken {
+                return true;
+            }
+            if (futex_q.bitset & bitset) != 0 && futex_q.key == key {
+                //WAIT_FOR_FUTEX.notify_task(&futex_q.task);
+                ret += 1;
+                return false;
+            }
+            return true;
+        })
+    }
+    // drop hash_bucket to avoid deadlock 
+    drop(hash_bucket);
+    yield_now_task();
+    Ok(ret as isize)
+}
+
+
+pub fn futex_requeue(uaddr: VirtAddr, flags: i32, nr_waken: u32, uaddr2: VirtAddr, nr_requeue: u32) -> AxSyscallResult {
+    let mut ret = 0;
+    let mut requeued = 0;
+    let key = get_futex_key(uaddr, flags);
+    let req_key = get_futex_key(uaddr2, flags);
+
+    if key == req_key {
+        return futex_wake(uaddr, flags, nr_waken);
+    } 
+
+
+
+    let mut hash_bucket= FUTEXQUEUES.buckets[futex_hash(&key)].lock();
+    if hash_bucket.is_empty() {
+        return Ok(0);
+    } 
+    else {
+        while let Some(futex_q) = hash_bucket.pop_front() {
+            if futex_q.key == key {
+                //WAIT_FOR_FUTEX.notify_task(&futex_q.task);
+                ret += 1;
+                if ret == nr_waken {
+                    break;
+                }
+            }
+        }
+        if hash_bucket.is_empty() {
+            return Ok(ret as isize);
+        }
+        // requeue the rest of the waiters
+        let mut req_bucket = FUTEXQUEUES.buckets[futex_hash(&req_key)].lock();
+        while let Some(futex_q) = hash_bucket.pop_front() {
+            req_bucket.push_back(futex_q); 
+            requeued += 1;
+            if requeued == nr_requeue {
+                break;
+            }
+        }
+    }
+    drop(hash_bucket);
+    yield_now_task();
+    Ok(ret as isize)
 }


### PR DESCRIPTION
- futex相关syscall的具体实现
- `exit_current_task`中在处理`clear_child_tid`时, 可能需要唤醒在其上等待的其他任务(参考Linux kernel/fork.c中`mm_release`)